### PR TITLE
Clean up upper level files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ecflow-related files
+*.job[1-9]
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,6 @@ def check_dependencies():
     except ImportError:
         install_requires.append('xarray')
     try:
-        import cartopy
-    except ImportError:
-        install_requires.append('cartopy')
-    try:
         import netCDF4
     except ImportError:
         install_requires.append('netCDF4')

--- a/tools/bin/ecflow/include/head.h
+++ b/tools/bin/ecflow/include/head.h
@@ -6,7 +6,7 @@ set -x # echo script lines as they are executed
  
 # Defines the variables that are needed for any communication with ECF
 export ECF_PORT=%ECF_PORT%    # The server port number
-export ECF_NODE=%ECF_NODE%    # The name of ecf host that issued this task
+export ECF_HOST=%ECF_HOST%    # The name of ecf host that issued this task
 export ECF_NAME=%ECF_NAME%    # The name of this current task
 export ECF_PASS=%ECF_PASS%    # A unique password
 export ECF_TRYNO=%ECF_TRYNO%  # Current try number of the task

--- a/tools/bin/ecflow/include/qsub.h
+++ b/tools/bin/ecflow/include/qsub.h
@@ -1,7 +1,8 @@
 #!/bin/bash
-#
-#$ -cwd
-#$ -j y
-#$ -S /bin/bash
-#
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -m e
+#PBS -M eclark2@uw.edu
+#PBS -l walltime=04:00:00
+#PBS -l nodes=1:ppn=16
 


### PR DESCRIPTION
1) Ignore job files generated by ecflow when running `git`.
2) Remove `cartopy` from `setup.py` requirements because plots are no longer made.
3) Replace `ECF_NODE` with `ECF_HOST` because the former is deprecated.
4) Switch `qsub` headings to PBS instead of SGE for use on hyak.